### PR TITLE
Link DOIs to preferred resolver

### DIFF
--- a/R/badge.R
+++ b/R/badge.R
@@ -128,7 +128,7 @@ badge_download_bioc <- function(pkg) {
 ##' @examples
 ##' badge_doi("10.1111/2041-210X.12628", "green")
 badge_doi <- function(doi, color) {
-    url <- paste0("http://dx.doi.org/",doi)
+    url <- paste0("https://doi.org/",doi)
     badge_custom("doi", doi, color, url)
 }
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Examples
 
 -   DOI
     -   syntax: `` `r badge_doi("10.1111/2041-210X.12628", "yellow")` ``
-    -   badge: [![](https://img.shields.io/badge/doi-10.1111/2041--210X.12628-yellow.svg?style=flat)](http://dx.doi.org/10.1111/2041-210X.12628)
+    -   badge: [![](https://img.shields.io/badge/doi-10.1111/2041--210X.12628-yellow.svg?style=flat)](https://doi.org/10.1111/2041-210X.12628)
 
 ### Customize badge
 


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Accordingly, this PR updates a static DOI link and the code that generates new ones.

Cheers!