### PR TITLE
Automatically detect pkg via DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,8 @@ Depends:
     R (>= 3.3.0)
 Imports:
     dlstats,
-    rvcheck
+    rvcheck,
+    desc
 License: Artistic-2.0
 ByteCompile: true
 URL: https://github.com/GuangchuangYu/badger

--- a/R/badge.R
+++ b/R/badge.R
@@ -221,7 +221,7 @@ badge_lifecycle <- function(stage = "experimental", color = NULL) {
 ##' @title badge_last_commit
 ##' @param ref Reference for a GitHub repository. If \code{NULL}
 ##'   (the default), the reference is determined by the URL
-##'   field in the description file.
+##'   field in the DESCRIPTION file.
 ##' @return badge in markdown syntax
 ##' @export
 ##' @author Gregor de Cillia
@@ -292,7 +292,7 @@ badge_cran_release <- function(pkg = NULL, color) {
 ##' @title badge_coveralls
 ##' @param ref Reference for a GitHub repository. If \code{NULL}
 ##'   (the default), the reference is determined by the URL
-##'   field in the description file.
+##'   field in the DESCRIPTION file.
 ##' @return badge in markdown syntax
 ##' @export
 ##' @author Gregor de Cillia

--- a/R/badge.R
+++ b/R/badge.R
@@ -2,13 +2,15 @@
 ##'
 ##'
 ##' @title badge_bioc_release
-##' @param pkg package
+##' @param pkg package. If \code{NULL} (the default) the package
+##'   is determined via the DESCRIPTION file.
 ##' @param color badge color
 ##' @return badge in markdown syntax
 ##' @export
 ##' @author Guangchuang Yu
 ##' @importFrom rvcheck check_bioc
-badge_bioc_release <- function(pkg, color) {
+badge_bioc_release <- function(pkg = NULL, color) {
+    pkg <- currentPackageName(pkg)
     v <- check_bioc(pkg)$latest_version
     url <- paste0("https://www.bioconductor.org/packages/", pkg)
     badge_custom("release version", v, color, url)
@@ -19,12 +21,14 @@ badge_bioc_release <- function(pkg, color) {
 ##'
 ##'
 ##' @title badge_github_version
-##' @param pkg package
+##' @param pkg package. If \code{NULL} (the default) the package
+##'   is determined via the DESCRIPTION file.
 ##' @param color badge color
 ##' @return badge in markdown syntax
 ##' @export
 ##' @author Guangchuang Yu
-badge_github_version <- function(pkg, color) {
+badge_github_version <- function(pkg = NULL, color) {
+    pkg <- currentGitHubRef(pkg)
     v <- ver_devel(pkg)
     url <- paste0("https://github.com/", pkg)
     badge_custom("devel version", v, color, url)
@@ -43,12 +47,13 @@ badge_devel <- badge_github_version
 ##'
 ##'
 ##' @title ver_devel
-##' @param pkg package name
+##' @param pkg package. If \code{NULL} (the default) the package
+##'   is determined via the DESCRIPTION file.
 ##' @return devel version
 ##' @author Guangchuang
 ##' @importFrom rvcheck check_github
 ##' @export
-ver_devel <- function (pkg) {
+ver_devel <- function (pkg = NULL) {
     ## flag <- FALSE
     ## if (file.exists("DESCRIPTION")) {
     ##     x <- readLines("DESCRIPTION")
@@ -64,7 +69,7 @@ ver_devel <- function (pkg) {
     ##         return(v)
     ##     }
     ## }
-
+    pkg <- currentGitHubRef(pkg)
     check_github(pkg)$latest_version
 }
 
@@ -72,7 +77,8 @@ ver_devel <- function (pkg) {
 ##'
 ##'
 ##' @title badge_bioc_download
-##' @param pkg package
+##' @param pkg package. If \code{NULL} (the default) the package
+##'   is determined via the DESCRIPTION file.
 ##' @param by one of total or month
 ##' @param color badge color
 ##' @param type one of distinct and total
@@ -80,7 +86,8 @@ ver_devel <- function (pkg) {
 ##' @export
 ##' @author Guangchuang Yu
 ##' @importFrom dlstats bioc_stats
-badge_bioc_download <- function(pkg, by, color, type="distinct") {
+badge_bioc_download <- function(pkg = NULL, by, color, type="distinct") {
+    pkg <- currentPackageName(pkg)
     type <- match.arg(type, c("distinct", "total"))
     dl <- "Nb_of_downloads"
     if (type == "distinct")
@@ -105,11 +112,13 @@ badge_bioc_download <- function(pkg, by, color, type="distinct") {
 ##'
 ##'
 ##' @title badge_download_bioc
-##' @param pkg package
+##' @param pkg package. If \code{NULL} (the default) the package
+##'   is determined via the DESCRIPTION file.
 ##' @return bioc download badge
 ##' @export
 ##' @author guangchuang yu
-badge_download_bioc <- function(pkg) {
+badge_download_bioc <- function(pkg = NULL) {
+    pkg <- currentPackageName(pkg)
     paste0("[![download](http://www.bioconductor.org/shields/downloads/",
            pkg, ".svg)](https://bioconductor.org/packages/stats/bioc/", pkg, ")")
 
@@ -210,11 +219,14 @@ badge_lifecycle <- function(stage = "experimental", color = NULL) {
 ##'
 ##'
 ##' @title badge_last_commit
-##' @param ref Reference for a GitHub repository
+##' @param ref Reference for a GitHub repository. If \code{NULL}
+##'   (the default), the reference is determined by the URL
+##'   field in the description file.
 ##' @return badge in markdown syntax
 ##' @export
 ##' @author Gregor de Cillia
-badge_last_commit <- function(ref) {
+badge_last_commit <- function(ref = NULL) {
+  ref <- currentGitHubRef(ref)
   url <- paste0("https://github.com/", ref, "/commits/master")
   svg <- paste0("https://img.shields.io/github/last-commit/", ref, ".svg")
   paste0("[![](", svg, ")](", url, ")")
@@ -224,11 +236,14 @@ badge_last_commit <- function(ref) {
 ##'
 ##'
 ##' @title badge_travis
-##' @param ref Reference for a GitHub repository
+##' @param ref Reference for a GitHub repository. If \code{NULL}
+##'   (the default), the reference is determined by the URL
+##'   field in the DESCRIPTION file.
 ##' @return badge in markdown syntax
 ##' @export
 ##' @author Gregor de Cillia
-badge_travis <- function(ref) {
+badge_travis <- function(ref = NULL) {
+  ref <- currentGitHubRef(ref)
   svg <- paste0("https://travis-ci.org/", ref, ".svg?branch=master")
   url <- paste0("https://travis-ci.org/", ref)
   paste0("[![](", svg, ")](", url, ")")
@@ -238,11 +253,14 @@ badge_travis <- function(ref) {
 ##'
 ##'
 ##' @title badge_code_size
-##' @param ref Reference for a GitHub repository
+##' @param ref Reference for a GitHub repository. If \code{NULL}
+##'   (the default), the reference is determined by the URL
+##'   field in the DESCRIPTION file.
 ##' @return badge in markdown syntax
 ##' @export
 ##' @author Gregor de Cillia
-badge_code_size <- function(ref) {
+badge_code_size <- function(ref = NULL) {
+  ref <- currentGitHubRef(ref)
   svg <- paste0("https://img.shields.io/github/languages/code-size/",
                 ref, ".svg")
   url <- paste0("https://github.com/", ref)
@@ -254,12 +272,14 @@ badge_code_size <- function(ref) {
 ##'
 ##'
 ##' @title badge_cran_release
-##' @param pkg package
+##' @param pkg package. If \code{NULL} (the default) the package
+##'   is determined via the DESCRIPTION file.
 ##' @param color color of badge
 ##' @return badge in markdown syntax
 ##' @export
 ##' @author Gregor de Cillia
-badge_cran_release <- function(pkg, color) {
+badge_cran_release <- function(pkg = NULL, color) {
+  pkg <- currentPackageName(pkg)
   svg <- paste0("https://www.r-pkg.org/badges/version/", pkg, "?color=", color)
   url <- paste0("https://cran.r-project.org/package=", pkg)
   placeholder <- "CRAN link"
@@ -270,11 +290,14 @@ badge_cran_release <- function(pkg, color) {
 ##'
 ##'
 ##' @title badge_coveralls
-##' @param ref Reference for a GitHub repository
+##' @param ref Reference for a GitHub repository. If \code{NULL}
+##'   (the default), the reference is determined by the URL
+##'   field in the description file.
 ##' @return badge in markdown syntax
 ##' @export
 ##' @author Gregor de Cillia
-badge_coveralls <- function(ref) {
+badge_coveralls <- function(ref = NULL) {
+  ref <- currentGitHubRef(ref)
   svg = paste0("https://coveralls.io/repos/github/", ref, "/badge.svg?branch=master")
   url <- paste0("https://coveralls.io/repos/github/", ref)
   placeholder <- "coveralls link"
@@ -285,14 +308,16 @@ badge_coveralls <- function(ref) {
 ##'
 ##'
 ##' @title badge_cran_download
-##' @param pkg package
+##' @param pkg package. If \code{NULL} (the default) the package
+##'   is determined via the DESCRIPTION file.
 ##' @param type type of stats. \code{last-month}, \code{last-week} or \code{"grand-total"}
 ##' @param color color of badge
 ##' @return badge in markdown syntax
 ##' @export
 ##' @author Gregor de Cillia
-badge_cran_download <- function(pkg, type = c("last-month", "last-week", "grand-total"),
+badge_cran_download <- function(pkg = NULL, type = c("last-month", "last-week", "grand-total"),
                                 color = "green") {
+  pkg <- currentPackageName(pkg)
 	type <- match.arg(type)
   svg <- paste0("http://cranlogs.r-pkg.org/badges/", type, "/", pkg, "?color=", color)
   url <- paste0("https://cran.r-project.org/package=", pkg)
@@ -303,11 +328,13 @@ badge_cran_download <- function(pkg, type = c("last-month", "last-week", "grand-
 ##' dependency badge
 ##'
 ##' @title badge_depedencies
-##' @param pkg package
+##' @param pkg package. If \code{NULL} (the default) the package
+##'   is determined via the DESCRIPTION file.
 ##' @return badge in markdown syntax
 ##' @export
 ##' @author Dirk Eddelbuettel
-badge_dependencies <- function(pkg) {
+badge_dependencies <- function(pkg = NULL) {
+    pkg <- currentPackageName(pkg)
     badge <- paste0("https://tinyverse.netlify.com/badge/", pkg)
     url <- paste0("https://cran.r-project.org/package=", pkg)
     placeholder <- "Dependencies"

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -1,1 +1,17 @@
 utils::globalVariables(".")
+
+currentPackageName <- function(pkg) {
+    if (!is.null(pkg))
+        return(pkg)
+    desc::desc_get_field("Package")
+}
+
+currentGitHubRef <- function(ref) {
+	if (!is.null(ref))
+		return(ref)
+	url <- desc::desc_get_field("URL")
+	if (!grepl("giTHub", url, ignore.case = TRUE))
+		stop("reference could not be determined by the DESCRIPTION' url")
+	ref <- gsub("https://github.com/", "", url)
+	ref
+}

--- a/man/badge_bioc_download.Rd
+++ b/man/badge_bioc_download.Rd
@@ -4,10 +4,11 @@
 \alias{badge_bioc_download}
 \title{badge_bioc_download}
 \usage{
-badge_bioc_download(pkg, by, color, type = "distinct")
+badge_bioc_download(pkg = NULL, by, color, type = "distinct")
 }
 \arguments{
-\item{pkg}{package}
+\item{pkg}{package. If \code{NULL} (the default) the package
+is determined via the DESCRIPTION file.}
 
 \item{by}{one of total or month}
 

--- a/man/badge_bioc_release.Rd
+++ b/man/badge_bioc_release.Rd
@@ -4,10 +4,11 @@
 \alias{badge_bioc_release}
 \title{badge_bioc_release}
 \usage{
-badge_bioc_release(pkg, color)
+badge_bioc_release(pkg = NULL, color)
 }
 \arguments{
-\item{pkg}{package}
+\item{pkg}{package. If \code{NULL} (the default) the package
+is determined via the DESCRIPTION file.}
 
 \item{color}{badge color}
 }

--- a/man/badge_code_size.Rd
+++ b/man/badge_code_size.Rd
@@ -4,10 +4,12 @@
 \alias{badge_code_size}
 \title{badge_code_size}
 \usage{
-badge_code_size(ref)
+badge_code_size(ref = NULL)
 }
 \arguments{
-\item{ref}{Reference for a GitHub repository}
+\item{ref}{Reference for a GitHub repository. If \code{NULL}
+(the default), the reference is determined by the URL
+field in the DESCRIPTION file.}
 }
 \value{
 badge in markdown syntax

--- a/man/badge_coveralls.Rd
+++ b/man/badge_coveralls.Rd
@@ -4,10 +4,12 @@
 \alias{badge_coveralls}
 \title{badge_coveralls}
 \usage{
-badge_coveralls(ref)
+badge_coveralls(ref = NULL)
 }
 \arguments{
-\item{ref}{Reference for a GitHub repository}
+\item{ref}{Reference for a GitHub repository. If \code{NULL}
+(the default), the reference is determined by the URL
+field in the description file.}
 }
 \value{
 badge in markdown syntax

--- a/man/badge_coveralls.Rd
+++ b/man/badge_coveralls.Rd
@@ -9,7 +9,7 @@ badge_coveralls(ref = NULL)
 \arguments{
 \item{ref}{Reference for a GitHub repository. If \code{NULL}
 (the default), the reference is determined by the URL
-field in the description file.}
+field in the DESCRIPTION file.}
 }
 \value{
 badge in markdown syntax

--- a/man/badge_cran_download.Rd
+++ b/man/badge_cran_download.Rd
@@ -4,11 +4,12 @@
 \alias{badge_cran_download}
 \title{badge_cran_download}
 \usage{
-badge_cran_download(pkg, type = c("last-month", "last-week",
+badge_cran_download(pkg = NULL, type = c("last-month", "last-week",
   "grand-total"), color = "green")
 }
 \arguments{
-\item{pkg}{package}
+\item{pkg}{package. If \code{NULL} (the default) the package
+is determined via the DESCRIPTION file.}
 
 \item{type}{type of stats. \code{last-month}, \code{last-week} or \code{"grand-total"}}
 

--- a/man/badge_cran_release.Rd
+++ b/man/badge_cran_release.Rd
@@ -4,10 +4,11 @@
 \alias{badge_cran_release}
 \title{badge_cran_release}
 \usage{
-badge_cran_release(pkg, color)
+badge_cran_release(pkg = NULL, color)
 }
 \arguments{
-\item{pkg}{package}
+\item{pkg}{package. If \code{NULL} (the default) the package
+is determined via the DESCRIPTION file.}
 
 \item{color}{color of badge}
 }

--- a/man/badge_dependencies.Rd
+++ b/man/badge_dependencies.Rd
@@ -4,10 +4,11 @@
 \alias{badge_dependencies}
 \title{badge_depedencies}
 \usage{
-badge_dependencies(pkg)
+badge_dependencies(pkg = NULL)
 }
 \arguments{
-\item{pkg}{package}
+\item{pkg}{package. If \code{NULL} (the default) the package
+is determined via the DESCRIPTION file.}
 }
 \value{
 badge in markdown syntax

--- a/man/badge_devel.Rd
+++ b/man/badge_devel.Rd
@@ -4,10 +4,11 @@
 \alias{badge_devel}
 \title{badge_devel}
 \usage{
-badge_devel(pkg, color)
+badge_devel(pkg = NULL, color)
 }
 \arguments{
-\item{pkg}{package}
+\item{pkg}{package. If \code{NULL} (the default) the package
+is determined via the DESCRIPTION file.}
 
 \item{color}{badge color}
 }

--- a/man/badge_download_bioc.Rd
+++ b/man/badge_download_bioc.Rd
@@ -4,10 +4,11 @@
 \alias{badge_download_bioc}
 \title{badge_download_bioc}
 \usage{
-badge_download_bioc(pkg)
+badge_download_bioc(pkg = NULL)
 }
 \arguments{
-\item{pkg}{package}
+\item{pkg}{package. If \code{NULL} (the default) the package
+is determined via the DESCRIPTION file.}
 }
 \value{
 bioc download badge

--- a/man/badge_github_version.Rd
+++ b/man/badge_github_version.Rd
@@ -4,10 +4,11 @@
 \alias{badge_github_version}
 \title{badge_github_version}
 \usage{
-badge_github_version(pkg, color)
+badge_github_version(pkg = NULL, color)
 }
 \arguments{
-\item{pkg}{package}
+\item{pkg}{package. If \code{NULL} (the default) the package
+is determined via the DESCRIPTION file.}
 
 \item{color}{badge color}
 }

--- a/man/badge_last_commit.Rd
+++ b/man/badge_last_commit.Rd
@@ -9,7 +9,7 @@ badge_last_commit(ref = NULL)
 \arguments{
 \item{ref}{Reference for a GitHub repository. If \code{NULL}
 (the default), the reference is determined by the URL
-field in the description file.}
+field in the DESCRIPTION file.}
 }
 \value{
 badge in markdown syntax

--- a/man/badge_last_commit.Rd
+++ b/man/badge_last_commit.Rd
@@ -4,10 +4,12 @@
 \alias{badge_last_commit}
 \title{badge_last_commit}
 \usage{
-badge_last_commit(ref)
+badge_last_commit(ref = NULL)
 }
 \arguments{
-\item{ref}{Reference for a GitHub repository}
+\item{ref}{Reference for a GitHub repository. If \code{NULL}
+(the default), the reference is determined by the URL
+field in the description file.}
 }
 \value{
 badge in markdown syntax

--- a/man/badge_travis.Rd
+++ b/man/badge_travis.Rd
@@ -4,10 +4,12 @@
 \alias{badge_travis}
 \title{badge_travis}
 \usage{
-badge_travis(ref)
+badge_travis(ref = NULL)
 }
 \arguments{
-\item{ref}{Reference for a GitHub repository}
+\item{ref}{Reference for a GitHub repository. If \code{NULL}
+(the default), the reference is determined by the URL
+field in the DESCRIPTION file.}
 }
 \value{
 badge in markdown syntax

--- a/man/ver_devel.Rd
+++ b/man/ver_devel.Rd
@@ -4,10 +4,11 @@
 \alias{ver_devel}
 \title{ver_devel}
 \usage{
-ver_devel(pkg)
+ver_devel(pkg = NULL)
 }
 \arguments{
-\item{pkg}{package name}
+\item{pkg}{package. If \code{NULL} (the default) the package
+is determined via the DESCRIPTION file.}
 }
 \value{
 devel version


### PR DESCRIPTION
I added some logic that automatically determines the packagename and the GitHub reference of the current package via the DESCRIPTION file. This means that the `badge_*` functions can be called more easily. For example

    badger::badge_cran_download()

will give a download badge  for the current package without needing any input parameters. The DESCRIPTION file is parsed with the `desc` package (a dependency of `roxygen2`).

    