### PR TITLE
Updating badge_travis

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,4 +21,4 @@ URL: https://github.com/GuangchuangYu/badger
 BugReports: https://github.com/GuangchuangYu/badger/issues
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 6.1.1
+RoxygenNote: 7.1.0

--- a/R/badge.R
+++ b/R/badge.R
@@ -243,13 +243,16 @@ badge_last_commit <- function(ref = NULL) {
 ##' @param ref Reference for a GitHub repository. If \code{NULL}
 ##'   (the default), the reference is determined by the URL
 ##'   field in the DESCRIPTION file.
+##' @param is_commercial Flad to indicate whether or not to use
+##'   https://travis-ci.com
 ##' @return badge in markdown syntax
 ##' @export
 ##' @author Gregor de Cillia
-badge_travis <- function(ref = NULL) {
+badge_travis <- function(ref = NULL, is_commercial = FALSE) {
   ref <- currentGitHubRef(ref)
-  svg <- paste0("https://travis-ci.org/", ref, ".svg?branch=master")
-  url <- paste0("https://travis-ci.org/", ref)
+  ext <- ifelse(is_commercial, "com/", "org/")
+  svg <- paste0("https://travis-ci.", ext, ref, ".svg?branch=master")
+  url <- paste0("https://travis-ci.", ext, ref)
   paste0("[![](", svg, ")](", url, ")")
 }
 

--- a/man/badge_cran_download.Rd
+++ b/man/badge_cran_download.Rd
@@ -4,8 +4,11 @@
 \alias{badge_cran_download}
 \title{badge_cran_download}
 \usage{
-badge_cran_download(pkg = NULL, type = c("last-month", "last-week",
-  "grand-total"), color = "green")
+badge_cran_download(
+  pkg = NULL,
+  type = c("last-month", "last-week", "grand-total"),
+  color = "green"
+)
 }
 \arguments{
 \item{pkg}{package. If \code{NULL} (the default) the package

--- a/man/badge_travis.Rd
+++ b/man/badge_travis.Rd
@@ -4,12 +4,15 @@
 \alias{badge_travis}
 \title{badge_travis}
 \usage{
-badge_travis(ref = NULL)
+badge_travis(ref = NULL, is_commercial = FALSE)
 }
 \arguments{
 \item{ref}{Reference for a GitHub repository. If \code{NULL}
 (the default), the reference is determined by the URL
 field in the DESCRIPTION file.}
+
+\item{is_commercial}{Flad to indicate whether or not to use
+https://travis-ci.com}
 }
 \value{
 badge in markdown syntax

--- a/ypages.Rproj
+++ b/ypages.Rproj
@@ -5,7 +5,12 @@ SaveWorkspace: No
 AlwaysSaveHistory: Default
 
 EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
 Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
 
 AutoAppendNewline: Yes
 StripTrailingWhitespace: Yes


### PR DESCRIPTION
I have added an extra parameter to the `badge_travis` function, so the user can choose if they want to link to the commercial version of Travis CI (https://travis-ci.com) or the original version https://travis-ci.org