### PR TITLE
Change default in badge_github_actions() to `action = "R-CMD-check"`

### DIFF
--- a/R/badge.R
+++ b/R/badge.R
@@ -391,7 +391,7 @@ badge_cran_checks <- function(pkg = NULL) {
 ##' @return badge in markdown syntax
 ##' @export
 ##' @author Alexander Rossell Hayes
-badge_github_actions <- function(ref = NULL, action = "R-CMD-CHECK") {
+badge_github_actions <- function(ref = NULL, action = "R-CMD-check") {
   ref <- currentGitHubRef(ref)
   svg <- paste0("https://github.com/", ref, "/workflows/", action, "/badge.svg")
   url <- paste0("https://github.com/", ref, "/actions")


### PR DESCRIPTION
Fixes a bug in my original submission of `badge_github_actions()`.

Originally the default was `action = "R-CMD-CHECK"`, but `usethis::use_github_action_*` by default makes a workflow called `R-CMD-check` (note the different capitalization).

This means that the original default argument would create a broken image in most instances. Sorry that I didn't catch this before my original pull request was accepted!