### PR TITLE
Document new functions

### DIFF
--- a/R/badge.R
+++ b/R/badge.R
@@ -396,12 +396,12 @@ badge_cran_checks <- function(pkg = NULL) {
 #' @return badge in markdown syntax
 #' @export
 #' @author Alexander Rossell Hayes
-badge_license <- function(license = NULL, color, url = NULL) {
+badge_license <- function(license = NULL, color = "blue", url = NULL) {
   if (is.null(license)) {
     license <- gsub(" \\+.*", "", desc::desc_get_field("License"))
   }
   badge <- paste0("https://img.shields.io/badge/license-",
-                  license, "-", color, ".svg")
+                  gsub("-", "--", license), "-", color, ".svg")
   if (is.null(url)) {
     url <- paste0("https://cran.r-project.org/web/licenses/", license)
   }

--- a/README.Rmd
+++ b/README.Rmd
@@ -117,6 +117,9 @@ devtools::install_github("GuangchuangYu/badger")
 + Lifecycle
 	- syntax: `` ``r ''`r badge_lifecycle("maturing", "blue")` ``
 	- badge: `r badge_lifecycle("maturing", "blue")`
++ License
+  - syntax: `` ``r ''`r badge_license("Artistic-2.0")` ``
+  - badge: `r badge_license("Artistic-2.0")`
 + travis build-status
 	- syntax: `` ``r ''`r badge_travis("rstudio/rmarkdown")` ``
 	- badge: `r badge_travis("rstudio/rmarkdown")`
@@ -138,6 +141,9 @@ devtools::install_github("GuangchuangYu/badger")
 + CRAN checks results
 	- syntax: `` ``r ''`r badge_cran_checks("badger")` ``
 	- badge: `r badge_cran_checks("badger")`
++ GitHub actions
+  - syntax: `` ``r ''`r badge_github_actions("rossellhayes/ipa")` ``
+  - badge: `r badge_github_actions("rossellhayes/ipa")`
 	
 ## :hammer: Related Tools
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ devtools::install_github("GuangchuangYu/badger")
   - release version (bioconductor)
       - syntax: `` `r badge_bioc_release("ggtree", "green")` ``
       - badge:
-        [![](https://img.shields.io/badge/release%20version-2.0.0-green.svg)](https://www.bioconductor.org/packages/ggtree)
+        [![](https://img.shields.io/badge/release%20version-2.2.2-green.svg)](https://www.bioconductor.org/packages/ggtree)
   - release version (CRAN)
       - syntax: `` `r badge_cran("badger", "orange")` ``
       - badge:
@@ -51,7 +51,7 @@ devtools::install_github("GuangchuangYu/badger")
   - devel version
       - syntax: `` `r badge_devel("guangchuangyu/ggtree", "blue")` ``
       - badge:
-        [![](https://img.shields.io/badge/devel%20version-2.1.1-blue.svg)](https://github.com/guangchuangyu/ggtree)
+        [![](https://img.shields.io/badge/devel%20version-0.0.8-blue.svg)](https://github.com/guangchuangyu/ggtree)
 
 ### Download stats for bioconductor
 
@@ -59,17 +59,17 @@ devtools::install_github("GuangchuangYu/badger")
       - syntax: `` `r badge_bioc_download("clusterProfiler", "total",
         "blue", "total")` ``
       - badge:
-        [![](https://img.shields.io/badge/download-291338/total-blue.svg)](https://bioconductor.org/packages/stats/bioc/clusterProfiler)
+        [![](https://img.shields.io/badge/download-404530/total-blue.svg)](https://bioconductor.org/packages/stats/bioc/clusterProfiler)
   - Total of distinct IPs
       - syntax: `` `r badge_bioc_download("clusterProfiler", "total",
         "yellow")` ``
       - badge:
-        [![](https://img.shields.io/badge/download-147091/total-yellow.svg)](https://bioconductor.org/packages/stats/bioc/clusterProfiler)
+        [![](https://img.shields.io/badge/download-208658/total-yellow.svg)](https://bioconductor.org/packages/stats/bioc/clusterProfiler)
   - Monthly download of distinct IPs
       - syntax: `` `r badge_bioc_download("clusterProfiler", "month",
         "green")` ``
       - badge:
-        [![](https://img.shields.io/badge/download-5387/month-green.svg)](https://bioconductor.org/packages/stats/bioc/clusterProfiler)
+        [![](https://img.shields.io/badge/download-7962/month-green.svg)](https://bioconductor.org/packages/stats/bioc/clusterProfiler)
 
 ### Download stats for CRAN
 
@@ -94,7 +94,7 @@ devtools::install_github("GuangchuangYu/badger")
   - Altmetric score
       - syntax: `` `r badge_altmetric("10533079", "green")` ``
       - badge:
-        [![](https://img.shields.io/badge/Altmetric-312-green.svg)](https://www.altmetric.com/details/10533079)
+        [![](https://img.shields.io/badge/Altmetric-313-green.svg)](https://www.altmetric.com/details/10533079)
 
 ### Academic
 
@@ -117,6 +117,10 @@ devtools::install_github("GuangchuangYu/badger")
       - syntax: `` `r badge_lifecycle("maturing", "blue")` ``
       - badge:
         [![](https://img.shields.io/badge/lifecycle-maturing-blue.svg)](https://www.tidyverse.org/lifecycle/#maturing)
+  - License
+      - syntax: `` `r badge_license("Artistic-2.0", "green")` ``
+      - badge: [![License:
+        Artistic-2.0](https://img.shields.io/badge/license-Artistic-2.0-green.svg)](https://cran.r-project.org/web/licenses/Artistic-2.0)
   - travis build-status
       - syntax: `` `r badge_travis("rstudio/rmarkdown")` ``
       - badge:
@@ -145,6 +149,10 @@ devtools::install_github("GuangchuangYu/badger")
       - syntax: `` `r badge_cran_checks("badger")` ``
       - badge: [![CRAN
         checks](https://cranchecks.info/badges/summary/badger)](https://cran.r-project.org/web/checks/check_results_badger.html)
+  - GitHub actions
+      - syntax: `` `r badge_github_actions("rossellhayes/ipa")` ``
+      - badge: [![R build
+        status](https://github.com/rossellhayes/ipa/workflows/R-CMD-check/badge.svg)](https://github.com/rossellhayes/ipa/actions)
 
 ## :hammer: Related Tools
 

--- a/man/badge_github_actions.Rd
+++ b/man/badge_github_actions.Rd
@@ -4,7 +4,7 @@
 \alias{badge_github_actions}
 \title{GitHub Actions badge}
 \usage{
-badge_github_actions(ref = NULL, action = "R-CMD-CHECK")
+badge_github_actions(ref = NULL, action = "R-CMD-check")
 }
 \arguments{
 \item{ref}{Reference for a GitHub repository. If \code{NULL} (the default),

--- a/man/badge_license.Rd
+++ b/man/badge_license.Rd
@@ -4,7 +4,7 @@
 \alias{badge_license}
 \title{License badge}
 \usage{
-badge_license(license = NULL, color, url = NULL)
+badge_license(license = NULL, color = "blue", url = NULL)
 }
 \arguments{
 \item{license}{The license to use. If \code{NULL} (the default), the license


### PR DESCRIPTION
Adds examples of `badge_license()` and `badge_github_actions()` to `README`.

Fixes:
- Licenses containing dashes (e.g. Artistic-2.0) no longer break `badge_license()` image.
- `badge_license()` now has a default color: blue (the default used for CRAN packages on shields.io).
- Documentation now reflects the change to the default action in `badge_github_actions()`.