### PR TITLE
Find GitHub URL for packages that list multiple URLs in DESCRIPTION

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -7,11 +7,16 @@ currentPackageName <- function(pkg) {
 }
 
 currentGitHubRef <- function(ref) {
-	if (!is.null(ref))
-		return(ref)
+	if (!is.null(ref)) {return(ref)}
+
 	url <- desc::desc_get_field("URL")
-	if (!grepl("gitHub", url, ignore.case = TRUE))
+	if (!grepl("gitHub", url, ignore.case = TRUE)) {
 		stop("reference could not be determined by the DESCRIPTION' url")
+	}
+
+	url <- unlist(strsplit(url, ",\\s*"))
+	url <- url[grepl("github", url, ignore.case = TRUE)][[1]]
+
 	ref <- gsub("https://github.com/", "", url)
 	ref
 }


### PR DESCRIPTION
Currently, currentGitHubRef() fails to format a GitHub URL if a package has multiple URLs listed in its `DESCRIPTION`. This is common for packages with `pkgdown` pages, e.g. the `tidyverse` packages.

This pull request adds code to `currentGitHubRef()` to extract only the GitHub URL in packages that list multiple URLs.* This ensures that badges are correctly formatted.

\* If a package lists two GitHub URLs for some reason, `currentGitHubRef()` returns the first.