### PR TITLE
Update `badge_lifecycle()` with new URL and support for superseded stage

### DIFF
--- a/R/badge.R
+++ b/R/badge.R
@@ -210,16 +210,18 @@ badge_sci_citation <- function(url, color) {
 ##'
 ##'
 ##' @title badge_lifcycle
-##' @param stage lifecycle stage See \href{https://www.tidyverse.org/lifecycle/}{https://www.tidyverse.org/lifecycle/}
+##' @param stage lifecycle stage See
+##'   \href{https://lifecycle.r-lib.org/articles/stages.html}{https://lifecycle.r-lib.org/articles/stages.html}
 ##' @param color color of the badge. If missing, the color is determined by the stage.
 ##' @return badge in markdown syntax
 ##' @export
 ##' @author Gregor de Cillia
 badge_lifecycle <- function(stage = "experimental", color = NULL) {
-  url <- paste0("https://www.tidyverse.org/lifecycle/#", stage)
+  url <- paste0("https://lifecycle.r-lib.org/articles/stages.html#", stage)
   if (is.null(color))
     color <- switch(stage, experimental = "orange", maturing = "blue", stable = "brightgreen",
                     retired = "orange", archived = "red", dormant = "blue", questioning = "blue",
+                    superseded = "blue",
                     stop("invalid stage: ", stage))
   badge_custom("lifecycle", stage, color, url)
 }


### PR DESCRIPTION
This PR updates the link in `badge_lifecycle()` to use the new lifecycle URL. This avoids a CRAN check for an out-of-date URL.

This PR also adds support for the `superseded` stage, which is the new name for `retired`. It does not remove support for `retired`.