### PR TITLE
Add argument `branch` to functions that require a branch name

### DIFF
--- a/R/badge.R
+++ b/R/badge.R
@@ -231,32 +231,34 @@ badge_lifecycle <- function(stage = "experimental", color = NULL) {
 ##' @param ref Reference for a GitHub repository. If \code{NULL}
 ##'   (the default), the reference is determined by the URL
 ##'   field in the DESCRIPTION file.
+##' @param branch The GitHub branch. Defaults to \code{"master"}.
 ##' @return badge in markdown syntax
 ##' @export
 ##' @author Gregor de Cillia
-badge_last_commit <- function(ref = NULL) {
+badge_last_commit <- function(ref = NULL, branch = "master") {
   ref <- currentGitHubRef(ref)
-  url <- paste0("https://github.com/", ref, "/commits/master")
+  url <- paste0("https://github.com/", ref, "/commits/", branch)
   svg <- paste0("https://img.shields.io/github/last-commit/", ref, ".svg")
   paste0("[![](", svg, ")](", url, ")")
 }
 
-##' reavis-ci badge
+##' travis-ci badge
 ##'
 ##'
 ##' @title badge_travis
 ##' @param ref Reference for a GitHub repository. If \code{NULL}
 ##'   (the default), the reference is determined by the URL
 ##'   field in the DESCRIPTION file.
-##' @param is_commercial Flad to indicate whether or not to use
+##' @param is_commercial Flag to indicate whether or not to use
 ##'   https://travis-ci.com
+##' @param branch The GitHub branch. Defaults to \code{"master"}.
 ##' @return badge in markdown syntax
 ##' @export
 ##' @author Gregor de Cillia
-badge_travis <- function(ref = NULL, is_commercial = FALSE) {
+badge_travis <- function(ref = NULL, is_commercial = FALSE, branch = "master") {
   ref <- currentGitHubRef(ref)
   ext <- ifelse(is_commercial, "com/", "org/")
-  svg <- paste0("https://travis-ci.", ext, ref, ".svg?branch=master")
+  svg <- paste0("https://travis-ci.", ext, ref, ".svg?branch=", branch)
   url <- paste0("https://travis-ci.", ext, ref)
   paste0("[![](", svg, ")](", url, ")")
 }
@@ -305,12 +307,13 @@ badge_cran_release <- function(pkg = NULL, color) {
 ##' @param ref Reference for a GitHub repository. If \code{NULL}
 ##'   (the default), the reference is determined by the URL
 ##'   field in the DESCRIPTION file.
+##' @param branch The GitHub branch. Defaults to \code{"master"}.
 ##' @return badge in markdown syntax
 ##' @export
 ##' @author Gregor de Cillia
-badge_coveralls <- function(ref = NULL) {
+badge_coveralls <- function(ref = NULL, branch = "master") {
   ref <- currentGitHubRef(ref)
-  svg = paste0("https://coveralls.io/repos/github/", ref, "/badge.svg?branch=master")
+  svg = paste0("https://coveralls.io/repos/github/", ref, "/badge.svg?branch=", branch)
   url <- paste0("https://coveralls.io/github/", ref)
   paste0("[![](", svg, ")](", url, ")")
 }
@@ -323,13 +326,14 @@ badge_coveralls <- function(ref = NULL) {
 ##'   (the default), the reference is determined by the URL
 ##'   field in the DESCRIPTION file.
 ##' @param token Codecov graphing token, needed for private repositories.
-##'   It can be obtained at https://codecov.io/gh/USER/REPO/branch/master/graph/
+##'   It can be obtained at https://codecov.io/gh/USER/REPO/branch/BRANCH/graph/
+##' @param branch The GitHub branch. Defaults to \code{"master"}.
 ##' @return badge in markdown syntax
 ##' @export
 ##' @author Gregor de Cillia
-badge_codecov <- function(ref = NULL, token = NULL) {
+badge_codecov <- function(ref = NULL, token = NULL, branch = "master") {
   ref <- currentGitHubRef(ref)
-  svg = paste0("https://codecov.io/gh/", ref, "/branch/master/graph/badge.svg")
+  svg = paste0("https://codecov.io/gh/", ref, "/branch/", branch, "/graph/badge.svg")
   if (!is.null(token)) {
     svg <- paste0(svg, "?token=", token)
   }

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -20,3 +20,4 @@ currentGitHubRef <- function(ref) {
 	ref <- gsub("https://github.com/", "", url)
 	ref
 }
+

--- a/man/badge_codecov.Rd
+++ b/man/badge_codecov.Rd
@@ -4,7 +4,7 @@
 \alias{badge_codecov}
 \title{badge_codecov}
 \usage{
-badge_codecov(ref = NULL, token = NULL)
+badge_codecov(ref = NULL, token = NULL, branch = "master")
 }
 \arguments{
 \item{ref}{Reference for a GitHub repository. If \code{NULL}
@@ -12,7 +12,9 @@ badge_codecov(ref = NULL, token = NULL)
 field in the DESCRIPTION file.}
 
 \item{token}{Codecov graphing token, needed for private repositories.
-It can be obtained at https://codecov.io/gh/USER/REPO/branch/master/graph/}
+It can be obtained at https://codecov.io/gh/USER/REPO/branch/BRANCH/graph/}
+
+\item{branch}{The GitHub branch. Defaults to \code{"master"}.}
 }
 \value{
 badge in markdown syntax

--- a/man/badge_coveralls.Rd
+++ b/man/badge_coveralls.Rd
@@ -4,12 +4,14 @@
 \alias{badge_coveralls}
 \title{badge_coveralls}
 \usage{
-badge_coveralls(ref = NULL)
+badge_coveralls(ref = NULL, branch = "master")
 }
 \arguments{
 \item{ref}{Reference for a GitHub repository. If \code{NULL}
 (the default), the reference is determined by the URL
 field in the DESCRIPTION file.}
+
+\item{branch}{The GitHub branch. Defaults to \code{"master"}.}
 }
 \value{
 badge in markdown syntax

--- a/man/badge_last_commit.Rd
+++ b/man/badge_last_commit.Rd
@@ -4,12 +4,14 @@
 \alias{badge_last_commit}
 \title{badge_last_commit}
 \usage{
-badge_last_commit(ref = NULL)
+badge_last_commit(ref = NULL, branch = "master")
 }
 \arguments{
 \item{ref}{Reference for a GitHub repository. If \code{NULL}
 (the default), the reference is determined by the URL
 field in the DESCRIPTION file.}
+
+\item{branch}{The GitHub branch. Defaults to \code{"master"}.}
 }
 \value{
 badge in markdown syntax

--- a/man/badge_travis.Rd
+++ b/man/badge_travis.Rd
@@ -4,21 +4,23 @@
 \alias{badge_travis}
 \title{badge_travis}
 \usage{
-badge_travis(ref = NULL, is_commercial = FALSE)
+badge_travis(ref = NULL, is_commercial = FALSE, branch = "master")
 }
 \arguments{
 \item{ref}{Reference for a GitHub repository. If \code{NULL}
 (the default), the reference is determined by the URL
 field in the DESCRIPTION file.}
 
-\item{is_commercial}{Flad to indicate whether or not to use
+\item{is_commercial}{Flag to indicate whether or not to use
 https://travis-ci.com}
+
+\item{branch}{The GitHub branch. Defaults to \code{"master"}.}
 }
 \value{
 badge in markdown syntax
 }
 \description{
-reavis-ci badge
+travis-ci badge
 }
 \author{
 Gregor de Cillia


### PR DESCRIPTION
This PR addresses #20 by adding the argument `branch` to `badge_codecov()`, `badge_coveralls()`, `badge_last_commit()`, and `badge_travis()`.
`branch` defaults to `"master"`, but allows the user to specify another branch name. This makes `badger` compatible with projects that use a different default branch name.

This PR is an intermediate solution to this problem. A fuller solution could automatically detect the user's default branch name, but would require an added dependency on `usethis` 2.0.0.