### PR TITLE
Automatic default branch

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,5 +22,4 @@ ByteCompile: true
 URL: https://github.com/GuangchuangYu/badger
 BugReports: https://github.com/GuangchuangYu/badger/issues
 Encoding: UTF-8
-LazyData: true
 RoxygenNote: 7.1.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,8 @@ Depends:
 Imports:
     dlstats,
     rvcheck,
-    desc
+    desc,
+    usethis
 License: Artistic-2.0
 ByteCompile: true
 URL: https://github.com/GuangchuangYu/badger

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Imports:
     dlstats,
     rvcheck,
     desc,
-    usethis
+    usethis (>= 2.0.0)
 License: Artistic-2.0
 ByteCompile: true
 URL: https://github.com/GuangchuangYu/badger

--- a/R/badge.R
+++ b/R/badge.R
@@ -233,14 +233,16 @@ badge_lifecycle <- function(stage = "experimental", color = NULL) {
 ##' @param ref Reference for a GitHub repository. If \code{NULL}
 ##'   (the default), the reference is determined by the URL
 ##'   field in the DESCRIPTION file.
-##' @param branch The GitHub branch. Defaults to \code{"master"}.
+##' @param branch The GitHub branch. If \code{NULL}
+##'   (the default), the default branch is automatically determined.
 ##' @return badge in markdown syntax
 ##' @export
 ##' @author Gregor de Cillia
-badge_last_commit <- function(ref = NULL, branch = "master") {
-  ref <- currentGitHubRef(ref)
-  url <- paste0("https://github.com/", ref, "/commits/", branch)
-  svg <- paste0("https://img.shields.io/github/last-commit/", ref, ".svg")
+badge_last_commit <- function(ref = NULL, branch = NULL) {
+  ref    <- currentGitHubRef(ref)
+  branch <- defaultBranch(branch)
+  url    <- paste0("https://github.com/", ref, "/commits/", branch)
+  svg    <- paste0("https://img.shields.io/github/last-commit/", ref, ".svg")
   paste0("[![](", svg, ")](", url, ")")
 }
 
@@ -253,15 +255,17 @@ badge_last_commit <- function(ref = NULL, branch = "master") {
 ##'   field in the DESCRIPTION file.
 ##' @param is_commercial Flag to indicate whether or not to use
 ##'   https://travis-ci.com
-##' @param branch The GitHub branch. Defaults to \code{"master"}.
+##' @param branch The GitHub branch. If \code{NULL}
+##'   (the default), the default branch is automatically determined.
 ##' @return badge in markdown syntax
 ##' @export
 ##' @author Gregor de Cillia
-badge_travis <- function(ref = NULL, is_commercial = FALSE, branch = "master") {
-  ref <- currentGitHubRef(ref)
-  ext <- ifelse(is_commercial, "com/", "org/")
-  svg <- paste0("https://travis-ci.", ext, ref, ".svg?branch=", branch)
-  url <- paste0("https://travis-ci.", ext, ref)
+badge_travis <- function(ref = NULL, is_commercial = FALSE, branch = NULL) {
+  ref    <- currentGitHubRef(ref)
+  branch <- defaultBranch(branch)
+  ext    <- ifelse(is_commercial, "com/", "org/")
+  svg    <- paste0("https://travis-ci.", ext, ref, ".svg?branch=", branch)
+  url    <- paste0("https://travis-ci.", ext, ref)
   paste0("[![](", svg, ")](", url, ")")
 }
 
@@ -309,14 +313,18 @@ badge_cran_release <- function(pkg = NULL, color) {
 ##' @param ref Reference for a GitHub repository. If \code{NULL}
 ##'   (the default), the reference is determined by the URL
 ##'   field in the DESCRIPTION file.
-##' @param branch The GitHub branch. Defaults to \code{"master"}.
+##' @param branch The GitHub branch. If \code{NULL}
+##'   (the default), the default branch is automatically determined.
 ##' @return badge in markdown syntax
 ##' @export
 ##' @author Gregor de Cillia
-badge_coveralls <- function(ref = NULL, branch = "master") {
-  ref <- currentGitHubRef(ref)
-  svg = paste0("https://coveralls.io/repos/github/", ref, "/badge.svg?branch=", branch)
-  url <- paste0("https://coveralls.io/github/", ref)
+badge_coveralls <- function(ref = NULL, branch = NULL) {
+  ref    <- currentGitHubRef(ref)
+  branch <- defaultBranch(branch)
+  svg    <- paste0(
+    "https://coveralls.io/repos/github/", ref, "/badge.svg?branch=", branch
+  )
+  url    <- paste0("https://coveralls.io/github/", ref)
   paste0("[![](", svg, ")](", url, ")")
 }
 
@@ -329,13 +337,17 @@ badge_coveralls <- function(ref = NULL, branch = "master") {
 ##'   field in the DESCRIPTION file.
 ##' @param token Codecov graphing token, needed for private repositories.
 ##'   It can be obtained at https://codecov.io/gh/USER/REPO/branch/BRANCH/graph/
-##' @param branch The GitHub branch. Defaults to \code{"master"}.
+##' @param branch The GitHub branch. If \code{NULL}
+##'   (the default), the default branch is automatically determined.
 ##' @return badge in markdown syntax
 ##' @export
 ##' @author Gregor de Cillia
-badge_codecov <- function(ref = NULL, token = NULL, branch = "master") {
-  ref <- currentGitHubRef(ref)
-  svg = paste0("https://codecov.io/gh/", ref, "/branch/", branch, "/graph/badge.svg")
+badge_codecov <- function(ref = NULL, token = NULL, branch = NULL) {
+  ref    <- currentGitHubRef(ref)
+  branch <- defaultBranch(branch)
+  svg    <- paste0(
+    "https://codecov.io/gh/", ref, "/branch/", branch, "/graph/badge.svg"
+  )
   if (!is.null(token)) {
     svg <- paste0(svg, "?token=", token)
   }

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -21,3 +21,7 @@ currentGitHubRef <- function(ref) {
 	ref
 }
 
+defaultBranch <- function(branch) {
+  if (!is.null(branch)) {return(branch)}
+  usethis::git_branch_default()
+}


### PR DESCRIPTION
This extends #22 and fully addresses #20 by adding functionality to automatically determine the default git branch. This changes the default value of `branch` in `badge_codecov()`, `badge_coveralls()`, `badge_last_commit()`, and `badge_travis()` to `NULL`. The `branch` can still be specified manually.

This adds a dependency on `usethis`.