### PR TITLE
Use dev version number

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: badger
 Title: Badge for R Package
-Version: 0.0.9
+Version: 0.0.9.9000
 Authors@R: c(
         person("Guangchuang", "Yu",          email = "guangchuangyu@gmail.com",    role = c("aut", "cre"), comment = c(ORCID = "0000-0002-6485-8781")),
         person("Gregor", "de Cillia",        email = "de.cillia.gregor@gmail.com", role = "ctb"),


### PR DESCRIPTION
This PR changes the current version number to the form x.x.x.9000, [as recommended for development versions](https://r-pkgs.org/description.html#version). This ensures that functions like `update.packages()` will not attempt to replace the development version of the package with the current CRAN version.