### PR TITLE
Remove trailing slash on URL

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -7,24 +7,24 @@ currentPackageName <- function(pkg) {
 }
 
 currentGitHubRef <- function(ref) {
-	if (!is.null(ref)) {return(ref)}
+  if (!is.null(ref)) {return(ref)}
 
-	url <- desc::desc_get_field("URL")
-	if (!grepl("gitHub", url, ignore.case = TRUE)) {
-		stop("reference could not be determined by the DESCRIPTION' url")
-	}
+  url <- desc::desc_get_field("URL")
+  if (!grepl("gitHub", url, ignore.case = TRUE)) {
+    stop("reference could not be determined by the DESCRIPTION' url")
+  }
 
-	url <- unlist(strsplit(url, ",\\s*"))
-	url <- url[grepl("github", url, ignore.case = TRUE)][[1]]
+  url <- unlist(strsplit(url, ",\\s*"))
+  url <- url[grepl("github", url, ignore.case = TRUE)][[1]]
 
-	ref <- gsub("https://github.com/", "", url)
+  ref <- gsub("https://github.com/", "", url)
 
-	# Removes eventual trailing slash on URL to fix svg filename
+  # Removes eventual trailing slash on URL to fix svg filename
   if (substring(ref, nchar(ref)) == "/") {
     ref <- gsub(".$", "", ref)
   }
 
-	ref
+  ref
 }
 
 defaultBranch <- function(branch) {

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -18,6 +18,12 @@ currentGitHubRef <- function(ref) {
 	url <- url[grepl("github", url, ignore.case = TRUE)][[1]]
 
 	ref <- gsub("https://github.com/", "", url)
+
+	# Removes eventual trailing slash on URL to fix svg filename
+  if (substring(ref, nchar(ref)) == "/") {
+    ref <- gsub(".$", "", ref)
+  }
+
 	ref
 }
 


### PR DESCRIPTION
Several badge functions simply get `ref` from `currentGitHubRef` and append a `.svg` to it. If the URL in the DESCRIPTION happens to end with a slash, that ends up breaking the badge, which will end up with a filename like `file/.svg` instead of `file.svg`. This PR proposes code to fix this.

I've done some impromptu tests and this seems to be working fine, but I am not 100% sure this doesn't break other badges (I couldn't find any unit test battery for this package).

Additionally, I've noticed some inconsistencies in the indentation on the `utilities.R` file, so I also fixed that.
