### PR TITLE
Allow `color = NULL` in `badge_cran_release()` and `badge_cran_download()`

### DIFF
--- a/R/badge.R
+++ b/R/badge.R
@@ -303,9 +303,10 @@ badge_code_size <- function(ref = NULL) {
 ##' @return badge in markdown syntax
 ##' @export
 ##' @author Gregor de Cillia
-badge_cran_release <- function(pkg = NULL, color) {
+badge_cran_release <- function(pkg = NULL, color = NULL) {
   pkg <- currentPackageName(pkg)
-  svg <- paste0("https://www.r-pkg.org/badges/version/", pkg, "?color=", color)
+  svg <- paste0("https://www.r-pkg.org/badges/version/", pkg)
+  if (!is.null(color)) {svg <- paste0(svg, "?color=", color)}
   url <- paste0("https://cran.r-project.org/package=", pkg)
   placeholder <- "CRAN link"
   paste0("[![](", svg, ")](", url, ")")
@@ -372,10 +373,11 @@ badge_codecov <- function(ref = NULL, token = NULL, branch = NULL) {
 ##' @export
 ##' @author Gregor de Cillia
 badge_cran_download <- function(pkg = NULL, type = c("last-month", "last-week", "grand-total"),
-                                color = "green") {
+                                color = NULL) {
   pkg <- currentPackageName(pkg)
 	type <- match.arg(type)
-  svg <- paste0("http://cranlogs.r-pkg.org/badges/", type, "/", pkg, "?color=", color)
+  svg <- paste0("http://cranlogs.r-pkg.org/badges/", type, "/", pkg)
+  if (!is.null(color)) {svg <- paste0(svg, "?color=", color)}
   url <- paste0("https://cran.r-project.org/package=", pkg)
   placeholder <- "CRAN link"
   paste0("[![](", svg, ")](", url, ")")

--- a/man/badge_cran_download.Rd
+++ b/man/badge_cran_download.Rd
@@ -7,7 +7,7 @@
 badge_cran_download(
   pkg = NULL,
   type = c("last-month", "last-week", "grand-total"),
-  color = "green"
+  color = NULL
 )
 }
 \arguments{

--- a/man/badge_cran_release.Rd
+++ b/man/badge_cran_release.Rd
@@ -4,7 +4,7 @@
 \alias{badge_cran_release}
 \title{badge_cran_release}
 \usage{
-badge_cran_release(pkg = NULL, color)
+badge_cran_release(pkg = NULL, color = NULL)
 }
 \arguments{
 \item{pkg}{package. If \code{NULL} (the default) the package


### PR DESCRIPTION
Sets `color = NULL` as a default argument in `badge_cran_release()` and `badge_cran_download()`. When `color = NULL`, these functions do not add a color specification to the requested badge URL, allowing the provider to serve a badge with their default color.

For example, this allows `badge_cran_release()` to serve a different color based on whether a package has been released:

``` r
badge_cran_release("badger")
#> [1] "[![](https://www.r-pkg.org/badges/version/badger)](https://cran.r-project.org/package=badger)"
```

[![](https://www.r-pkg.org/badges/version/badger)](https://cran.r-project.org/package=badger)


``` r
badge_cran_release("unreleased")
#> [1] "[![](https://www.r-pkg.org/badges/version/unreleased)](https://cran.r-project.org/package=unreleased)"
```

[![](https://www.r-pkg.org/badges/version/unreleased)](https://cran.r-project.org/package=unreleased)

<sup>Created on 2021-09-23 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>