### PR TITLE
Update codecov URL

### DIFF
--- a/R/badge.R
+++ b/R/badge.R
@@ -357,7 +357,7 @@ badge_codecov <- function(ref = NULL, token = NULL, branch = NULL) {
   if (!is.null(token)) {
     svg <- paste0(svg, "?token=", token)
   }
-  url <- paste0("https://codecov.io/gh/", ref)
+  url <- paste0("https://app.codecov.io/gh/", ref)
   paste0("[![](", svg, ")](", url, ")")
 }
 


### PR DESCRIPTION
This PR updates the codecov URL to `https://app.codecov.io/`. The previous URL, `https://codecov.io/` still works, but creates a redirect that triggers a NOTE in CRAN checks.