### PR TITLE
Updated codecov SVG URL + unit test

### DIFF
--- a/R/badge.R
+++ b/R/badge.R
@@ -352,7 +352,7 @@ badge_codecov <- function(ref = NULL, token = NULL, branch = NULL) {
   ref    <- currentGitHubRef(ref)
   branch <- defaultBranch(branch)
   svg    <- paste0(
-    "https://codecov.io/gh/", ref, "/branch/", branch, "/graph/badge.svg"
+    "https://app.codecov.io/gh/", ref, "/branch/", branch, "/graph/badge.svg"
   )
   if (!is.null(token)) {
     svg <- paste0(svg, "?token=", token)
@@ -473,4 +473,3 @@ badge_codefactor <- function(ref = NULL) {
   svg <- paste0(url, "/badge")
   paste0("[![CodeFactor](", svg, ")](", url, ")")
 }
-

--- a/tests/testthat/test-badges.R
+++ b/tests/testthat/test-badges.R
@@ -104,6 +104,7 @@ test_that("Other badges output as expected", {
       "lifecycle.r-lib.org/articles/stages.html#experimental"
     )
   )
+
   expect_equal(
     badge_last_commit("GuangchuangYu/badger", "master"),
     assembleBadgeOutput(
@@ -135,8 +136,8 @@ test_that("Other badges output as expected", {
   expect_equal(
     badge_codecov("GuangchuangYu/badger", branch="master"),
     assembleBadgeOutput(
-      "codecov.io/gh/GuangchuangYu/badger/branch/master/graph/badge.svg",
-      "codecov.io/gh/GuangchuangYu/badger"
+      "app.codecov.io/gh/GuangchuangYu/badger/branch/master/graph/badge.svg",
+      "app.codecov.io/gh/GuangchuangYu/badger"
     )
   )
   expect_equal(


### PR DESCRIPTION
Commit a4b126acf4752cb44885383446e076e5db3083ac added app. to the codecov badge `url` object. This broke some unit tests expectations, which this PR fixes. I am also assuming that "app." should be prefixed to the .svg image URL as well, so I also made that change (even though it doesn't seem to make a difference right now.
