### PR TITLE
Flag in badge_cran_checks to obtain 'worst' instead of 'summary' badges

### DIFF
--- a/R/badge.R
+++ b/R/badge.R
@@ -445,13 +445,20 @@ badge_dependencies <- function(pkg = NULL) {
 ##' @title badge_cran_checks
 ##' @param pkg package. If \code{NULL} (the default) the package
 ##'   is determined via the DESCRIPTION file.
+##' @param worst logical; if FALSE (default) return "summary" badge. If TRUE,
+##'   return "worst" badge.
 ##' @return badge in Markdown syntax
 ##' @export
 ##' @author Scott Chamberlain (badges API), Maëlle Salmon (function)
-badge_cran_checks <- function(pkg = NULL) {
+badge_cran_checks <- function(pkg = NULL, worst = FALSE) {
   pkg <- currentPackageName(pkg)
+  stopifnot(is.logical(worst))
   # badge <- paste0("https://cranchecks.info/badges/summary/", pkg)
-  badge <- paste0("https://badges.cranchecks.info/summary/", pkg, ".svg")
+  badge <- if (worst) {
+    badge <- paste0("https://badges.cranchecks.info/worst/", pkg, ".svg")
+  } else {
+    badge <- paste0("https://badges.cranchecks.info/summary/", pkg, ".svg")
+  }
   url <- paste0("https://cran.r-project.org/web/checks/check_results_",
                 pkg, ".html")
   placeholder <- "CRAN checks"

--- a/man/badge_cran_checks.Rd
+++ b/man/badge_cran_checks.Rd
@@ -4,11 +4,14 @@
 \alias{badge_cran_checks}
 \title{badge_cran_checks}
 \usage{
-badge_cran_checks(pkg = NULL)
+badge_cran_checks(pkg = NULL, worst = FALSE)
 }
 \arguments{
 \item{pkg}{package. If \code{NULL} (the default) the package
 is determined via the DESCRIPTION file.}
+
+\item{worst}{logical; if FALSE (default) return "summary" badge. If TRUE,
+return "worst" badge.}
 }
 \value{
 badge in Markdown syntax

--- a/tests/testthat/test-badges.R
+++ b/tests/testthat/test-badges.R
@@ -64,6 +64,14 @@ test_that("CRAN badges output as expected", {
       "CRAN checks"
     )
   )
+  expect_equal(
+    badge_cran_checks("badger", worst = TRUE),
+    assembleBadgeOutput(
+      "badges.cranchecks.info/worst/badger.svg",
+      "cran.r-project.org/web/checks/check_results_badger.html",
+      "CRAN checks"
+    )
+  )
 })
 
 test_that("Other badges output as expected", {


### PR DESCRIPTION
The cran check badge has two flavors, "worst" and "summary":

https://badges.cranchecks.info/summary/badger.svg
https://badges.cranchecks.info/worst/badger.svg

At current, "summary" is always used. This PR adds an optional argument to `badge_cran_checks()` to return the "worst" version instead. The default is to return "summary" as it currently does.