### PR TITLE
Update Codecov URL

### DIFF
--- a/R/badge.R
+++ b/R/badge.R
@@ -398,7 +398,7 @@ badge_codecov <- function(ref = NULL, token = NULL, branch = NULL) {
   if (!is.null(token)) {
     svg <- paste0(svg, "?token=", token)
   }
-  url <- paste0("https://codecov.io/gh/", ref)
+  url <- paste0("https://app.codecov.io/gh/", ref)
   paste0("[![](", svg, ")](", url, ")")
 }
 


### PR DESCRIPTION
Looks like Codecov has changed their base URL yet again. This PR updates the base URL in `badge_codecov()` to avoid issues with URL redirects.